### PR TITLE
remove the unnecessary .git from repo url

### DIFF
--- a/_data/themes.yml
+++ b/_data/themes.yml
@@ -4,7 +4,7 @@
     aesthetic fluff. It’s mobile first, fluidly responsive, and delightfully lightweight.
   image: pixyll.png
   demourl: http://pixyll.com
-  githuburl: https://github.com/johnotander/pixyll.git
+  githuburl: https://github.com/johnotander/pixyll
   author:
     name: John Otander
     url: http://johnotander.com


### PR DESCRIPTION
Sometimes if you roll your own git server, you have to have ".git" in the end of urls, but that's not the case with GitHub, and they redirect urls to a non ".git" version.
